### PR TITLE
feat: add button limit test command

### DIFF
--- a/packages/examples/src/example-bot.tsx
+++ b/packages/examples/src/example-bot.tsx
@@ -65,6 +65,55 @@ const TodoApp = () => {
   );
 };
 
+const ButtonLimitTestApp = () => {
+  return (
+    <>
+      <b>🚫 Button Limit Test</b>
+      <br />
+      <br />
+      This command creates too many buttons to test the button limit error.
+      <br />
+      <br />
+      <row>
+        <button onClick={() => {}}>Button 1</button>
+        <button onClick={() => {}}>Button 2</button>
+        <button onClick={() => {}}>Button 3</button>
+        <button onClick={() => {}}>Button 4</button>
+        <button onClick={() => {}}>Button 5</button>
+        <button onClick={() => {}}>Button 6</button>
+        <button onClick={() => {}}>Button 7</button>
+        <button onClick={() => {}}>Button 8</button>
+        <button onClick={() => {}}>Button 9</button>
+        <button onClick={() => {}}>Button 10</button>
+      </row>
+      <row>
+        <button onClick={() => {}}>Button 11</button>
+        <button onClick={() => {}}>Button 12</button>
+        <button onClick={() => {}}>Button 13</button>
+        <button onClick={() => {}}>Button 14</button>
+        <button onClick={() => {}}>Button 15</button>
+        <button onClick={() => {}}>Button 16</button>
+        <button onClick={() => {}}>Button 17</button>
+        <button onClick={() => {}}>Button 18</button>
+        <button onClick={() => {}}>Button 19</button>
+        <button onClick={() => {}}>Button 20</button>
+      </row>
+      <row>
+        <button onClick={() => {}}>Button 21</button>
+        <button onClick={() => {}}>Button 22</button>
+        <button onClick={() => {}}>Button 23</button>
+        <button onClick={() => {}}>Button 24</button>
+        <button onClick={() => {}}>Button 25</button>
+        <button onClick={() => {}}>Button 26</button>
+        <button onClick={() => {}}>Button 27</button>
+        <button onClick={() => {}}>Button 28</button>
+        <button onClick={() => {}}>Button 29</button>
+        <button onClick={() => {}}>Button 30</button>
+      </row>
+    </>
+  );
+};
+
 const HelpApp = () => {
   const [section, setSection] = useState<'main' | 'formatting' | 'features'>('main');
   
@@ -142,6 +191,8 @@ const HelpApp = () => {
       <br />
       /todo - Todo list manager
       <br />
+      /buttontest - Test button limit error
+      <br />
       /help - This help message
       <br />
       <br />
@@ -175,6 +226,7 @@ async function main() {
   adapter.onCommand('help', () => <HelpApp />);
   adapter.onCommand('counter', () => <CounterApp />);
   adapter.onCommand('todo', () => <TodoApp />);
+  adapter.onCommand('buttontest', () => <ButtonLimitTestApp />);
   
   // Start the bot
   await adapter.start(config.botToken);

--- a/packages/mtcute-adapter/src/mtcute-adapter.ts
+++ b/packages/mtcute-adapter/src/mtcute-adapter.ts
@@ -225,11 +225,19 @@ export class MtcuteAdapter {
     if (rows.length === 0) return undefined;
     
     const keyboard: tl.TypeKeyboardButton[][] = rows.map(row => 
-      row.children.map(button => ({
+    {
+      const rowButtons = row.children.map(button => ({
         _: 'keyboardButtonCallback',
         text: button.text,
         data: Buffer.from(`${containerId}:${button.id}`)
       }) as tl.TypeKeyboardButton)
+
+      if (rowButtons.length >8) {
+        throw new Error('Row has more than 8 buttons');
+      };
+
+      return rowButtons;
+    }
     );
     
     return { _: 'replyInlineMarkup', rows: keyboard.map(row => ({ _: 'keyboardButtonRow', buttons: row })) };
@@ -248,23 +256,28 @@ export class MtcuteAdapter {
     
     // Set up re-render callback
     container.container.onRenderContainer = async (root) => {
-      const textWithEntities = this.rootNodeToTextWithEntities(root);
-      const replyMarkup = this.rootNodeToInlineKeyboard(root, containerId);
-      
-      if (messageId === null) {
-        // First render: send a new message
-        const sentMessage = await this.client.sendText(chatId, textWithEntities, {
-          replyMarkup
-        });
-        messageId = sentMessage.id;
-      } else {
-        // Subsequent renders: edit the existing message
-        await this.client.editMessage({
-          chatId,
-          message: messageId,
-          text: textWithEntities,
-          replyMarkup
-        });
+      try {
+        const textWithEntities = this.rootNodeToTextWithEntities(root);
+        const replyMarkup = this.rootNodeToInlineKeyboard(root, containerId);
+        
+        if (messageId === null) {
+          // First render: send a new message
+          const sentMessage = await this.client.sendText(chatId, textWithEntities, {
+            replyMarkup
+          });
+          messageId = sentMessage.id;
+        } else {
+          // Subsequent renders: edit the existing message
+          await this.client.editMessage({
+            chatId,
+            message: messageId,
+            text: textWithEntities,
+              replyMarkup
+            });
+          }
+      } catch (err) {
+        console.error('Error sending message:', err);
+        await this.client.sendText(chatId, 'Error sending message, please try again later.');
       }
     };
     


### PR DESCRIPTION
## Summary
• Add `/buttontest` command to example bot
• Creates 30 buttons across multiple rows to test Telegram button limits
• Helps test error handling when button limits are exceeded

## Test plan
- [ ] Run the example bot
- [ ] Use `/buttontest` command
- [ ] Verify button limit error is triggered
- [ ] Check error handling works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)